### PR TITLE
update Compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.3"
+version: "3.6"
 services:
   android_emulator:
     build: /


### PR DESCRIPTION
update from 'Docker Engine release' 17.06.0+
to support 18.02.0+

I'm not sure what's the disadvantages is